### PR TITLE
Changed gnewsclient.py so it works with current GoogleNews

### DIFF
--- a/gnewsclient/gnewsclient.py
+++ b/gnewsclient/gnewsclient.py
@@ -132,7 +132,7 @@ class gnewsclient:
         for entry in entries:
             article = {}
             article['title'] = entry.title.text
-            article['link'] = entry.link['href'].split('&url=')[1]
+            article['link'] = entry.link['href']
             article['releasedAt'] = entry.updated.text
 
             try:


### PR DESCRIPTION
I run into problem, most likely due to GoogleNews link structure changes, when split couldn't work because there was no '&url=', so reffering to [1] returned IndexOutOfRange.
Removed split, so it works now (at least for me).